### PR TITLE
Fix include & function calls when Updater is disabled via cmake

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -280,7 +280,9 @@ int main(int argc, char** argv) {
     while (SDL_PollEvent(&event)) {
       SDLWindow::handleEvent(event);
       ConfigWindow::handleEvent(event);
+#ifdef USE_UPDATER
       UpdaterWindow::handleEvent(event);
+#endif
       WindowManager::handleEvent(event);
       Plugin::handleEvent(event);
     }
@@ -318,7 +320,9 @@ int main(int argc, char** argv) {
     SDLWindow::clear();
     WindowManager::render();
     ConfigWindow::draw();
+#ifdef USE_UPDATER
     UpdaterWindow::draw();
+#endif
     Plugin::drawAll();
     SDLWindow::display();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,6 @@
 #include "include/sdl_window.hpp"
 #include "include/spline.hpp"
 #include "include/theme.hpp"
-#include "include/update_window.hpp"
 #include "include/window_manager.hpp"
 
 #include <SDL3/SDL_main.h>
@@ -40,6 +39,8 @@
 #endif
 
 #ifdef USE_UPDATER
+#include "include/update_window.hpp"
+
 #include <curl/curl.h>
 #endif
 


### PR DESCRIPTION
There is currently an issue where compiling with `-D USE_UPDATER=0` fails:

```bash
$ cmake \
    -G Ninja \
    -D USE_UPDATER=0\
    -D CMAKE_BUILD_TYPE=Release \
    -D CMAKE_INSTALL_PREFIX=$HOME/.local \
    .. && ninja

# ...

/usr/bin/ld: /tmp/lto-llvm-cd94d1.o: in function 'main':
ld-temp.o:(.text.main+0x4720): undefined reference to 'UpdaterWindow::handleEvent(SDL_Event const&)'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

This PR moves out all references to functions in the Updater (`e4e6bdd`) and only includes the updater's header when you actually compile with the updater enabled (`2b7bb86`)